### PR TITLE
Add support for separating out platform config

### DIFF
--- a/charts/ploigos-workflow-minimal-tekton-pipeline/templates/Pipeline_ploigos-workflow-minimal.yml
+++ b/charts/ploigos-workflow-minimal-tekton-pipeline/templates/Pipeline_ploigos-workflow-minimal.yml
@@ -15,6 +15,14 @@ spec:
     description: |
       Workspace to checkout the application this workflow is for and set as the working directory
       for the step executions.
+  {{- if $.Values.global.separatePlatformConfig }}
+  - name: ploigos-platform-config
+    description: |
+      Workspace containing platform-level config
+  - name: ploigos-platform-config-secrets
+    description: |
+      Workspace containing platform-level secrets
+  {{- end }}
   params:
     - name: verbose
       description: log any *sh commands used during execution
@@ -405,6 +413,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -445,6 +459,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -485,6 +505,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -525,6 +551,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -565,6 +597,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -605,6 +643,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -662,6 +706,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -736,6 +786,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -803,6 +859,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)

--- a/charts/ploigos-workflow-minimal-tekton-pipeline/values.yaml
+++ b/charts/ploigos-workflow-minimal-tekton-pipeline/values.yaml
@@ -290,7 +290,7 @@ global:
   # https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#configuring-ssh-auth-authentication-for-git
   tektonGitSSHKeys: {}
 
-  # Flag indicating that platform-level configuration is separate from 
+  # Flag indicating that platform-level configuration is separate from
   # app-level configuration, and that the ploigos-step-runner ClusterTask
   # should expect to find:
   # - Platform config mounted in /opt/ploigos-platform-config

--- a/charts/ploigos-workflow-minimal-tekton-pipeline/values.yaml
+++ b/charts/ploigos-workflow-minimal-tekton-pipeline/values.yaml
@@ -290,5 +290,16 @@ global:
   # https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#configuring-ssh-auth-authentication-for-git
   tektonGitSSHKeys: {}
 
+  # Flag indicating that platform-level configuration is separate from 
+  # app-level configuration, and that the ploigos-step-runner ClusterTask
+  # should expect to find:
+  # - Platform config mounted in /opt/ploigos-platform-config
+  # - Platform config secrets mounted in /opt/ploigos-platform-config-secrets
+  #
+  # This flag also adds two workspaces to the pipeline template:
+  # - ploigos-platform-config: for mounting a ConfigMap
+  # - ploigos-platform-config-secrets: for mounting a Secret
+  separatePlatformConfig: false
+
 ploigos-workflow-tekton-shared-resources:
   nameOverride: ploigos-workflow-minimal-tekton-pipeline

--- a/charts/ploigos-workflow-shared-resources/templates/ServiceAccount_workflow.yml
+++ b/charts/ploigos-workflow-shared-resources/templates/ServiceAccount_workflow.yml
@@ -15,7 +15,7 @@ metadata:
   labels:
     {{- include "ploigos-workflow.labels" $ | nindent 4 }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: {{ $.Values.global.workflowWorkerRunAsUserRoleName }}
   apiGroup: rbac.authorization.k8s.io
 subjects:

--- a/charts/ploigos-workflow-standard-tekton-pipeline/templates/Pipeline_ploigos-workflow-standard.yml
+++ b/charts/ploigos-workflow-standard-tekton-pipeline/templates/Pipeline_ploigos-workflow-standard.yml
@@ -15,6 +15,14 @@ spec:
     description: |
       Workspace to checkout the application this workflow is for and set as the working directory
       for the step executions.
+  {{- if $.Values.global.separatePlatformConfig }}
+  - name: ploigos-platform-config
+    description: |
+      Workspace containing platform-level config
+  - name: ploigos-platform-config-secrets
+    description: |
+      Workspace containing platform-level secrets
+  {{- end }}
   params:
     - name: verbose
       description: log any *sh commands used during execution
@@ -438,6 +446,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -478,6 +492,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -518,6 +538,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -558,6 +584,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -598,6 +630,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -638,6 +676,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -678,6 +722,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -718,6 +768,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -766,6 +822,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -807,6 +869,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -847,6 +915,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -904,6 +978,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -946,6 +1026,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -988,6 +1074,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -1062,6 +1154,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -1104,6 +1202,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -1146,6 +1250,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -1213,6 +1323,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)
@@ -1255,6 +1371,12 @@ spec:
       workspace: home
     - name: app
       workspace: app
+    {{- if $.Values.global.separatePlatformConfig }}
+    - name: ploigos-platform-config
+      workspace: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      workspace: ploigos-platform-config-secrets
+    {{- end }}
     params:
     - name: verbose
       value: $(params.verbose)

--- a/charts/ploigos-workflow-standard-tekton-pipeline/values.yaml
+++ b/charts/ploigos-workflow-standard-tekton-pipeline/values.yaml
@@ -311,5 +311,16 @@ global:
   # https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#configuring-ssh-auth-authentication-for-git
   tektonGitSSHKeys: {}
 
+  # Flag indicating that platform-level configuration is separate from 
+  # app-level configuration, and that the ploigos-step-runner ClusterTask
+  # should expect to find:
+  # - Platform config mounted in /opt/ploigos-platform-config
+  # - Platform config secrets mounted in /opt/ploigos-platform-config-secrets
+  #
+  # This flag also adds two workspaces to the pipeline template:
+  # - ploigos-platform-config: for mounting a ConfigMap
+  # - ploigos-platform-config-secrets: for mounting a Secret
+  separatePlatformConfig: false
+
 ploigos-workflow-tekton-shared-resources:
   nameOverride: ploigos-workflow-standard-tekton-pipeline

--- a/charts/ploigos-workflow-standard-tekton-pipeline/values.yaml
+++ b/charts/ploigos-workflow-standard-tekton-pipeline/values.yaml
@@ -311,7 +311,7 @@ global:
   # https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#configuring-ssh-auth-authentication-for-git
   tektonGitSSHKeys: {}
 
-  # Flag indicating that platform-level configuration is separate from 
+  # Flag indicating that platform-level configuration is separate from
   # app-level configuration, and that the ploigos-step-runner ClusterTask
   # should expect to find:
   # - Platform config mounted in /opt/ploigos-platform-config

--- a/charts/ploigos-workflow-tekton-cluster-resources/templates/ClusterTask_ploigos-step-runner.yml
+++ b/charts/ploigos-workflow-tekton-cluster-resources/templates/ClusterTask_ploigos-step-runner.yml
@@ -22,6 +22,16 @@ spec:
     description: |
       Workspace with the checked out application in to use as the
       working directory for the step execution.
+  {{- if $.Values.separatePlatformConfig }}
+  - name: ploigos-platform-config
+    description: |
+      ConfigMap containing platform-level config
+    mountPath: /opt/platform-config
+  - name: ploigos-platform-config-secrets
+    description: |
+      Secret containing platform-level secrets
+    mountPath: /opt/platform-config-secrets
+  {{- end }}
   params:
   - name: verbose
     description: log the commands used during execution
@@ -125,6 +135,14 @@ spec:
       # REASONS:
       #   * https://github.com/tektoncd/pipeline/issues/3509
       passwd_home=$(getent passwd $(whoami) | cut -d: -f6)
+
+      if [ ! -d ${passwd_home}/.ssh ]; then
+        mkdir ${passwd_home}/.ssh
+        touch ${passwd_home}/.ssh/known_hosts
+        touch ${passwd_home}/.ssh/config
+        touch ${passwd_home}/.ssh/id_*
+      fi
+
       if [ "$(stat -c %a ${passwd_home}/.ssh)" != "700" ]; then
         echo "****************************"
         echo "* Fix .ssh dir permissions *"
@@ -142,6 +160,6 @@ spec:
       source $(params.venvPath)/bin/activate
 
       psr \
-          --config "$(params.stepRunnerConfigDir)" \
+          --config $(params.stepRunnerConfigDir) \
           --step "$(params.stepName)" \
           --environment "$(params.environment)"

--- a/charts/ploigos-workflow-tekton-cluster-resources/values.yaml
+++ b/charts/ploigos-workflow-tekton-cluster-resources/values.yaml
@@ -24,7 +24,7 @@ rbacCreate: true
 # resolved and this parameter can be passed at runtime.
 imagePullPolicy: IfNotPresent
 
-# Flag indicating that platform-level configuration is separate from 
+# Flag indicating that platform-level configuration is separate from
 # app-level configuration, and that the ploigos-step-runner ClusterTask
 # should expect to find:
 # - Platform config mounted in /opt/ploigos-platform-config

--- a/charts/ploigos-workflow-tekton-cluster-resources/values.yaml
+++ b/charts/ploigos-workflow-tekton-cluster-resources/values.yaml
@@ -23,3 +23,14 @@ rbacCreate: true
 # This is a temporary parameter until See https://github.com/tektoncd/pipeline/issues/3423 is
 # resolved and this parameter can be passed at runtime.
 imagePullPolicy: IfNotPresent
+
+# Flag indicating that platform-level configuration is separate from 
+# app-level configuration, and that the ploigos-step-runner ClusterTask
+# should expect to find:
+# - Platform config mounted in /opt/ploigos-platform-config
+# - Platform config secrets mounted in /opt/ploigos-platform-config-secrets
+#
+# This flag also adds two workspaces to the pipeline template:
+# - ploigos-platform-config: for mounting a ConfigMap
+# - ploigos-platform-config-secrets: for mounting a Secret
+separatePlatformConfig: false


### PR DESCRIPTION
Some notes:

1. Not sure if I put `separatePlatformConfig` in the right spot in `values.yaml` files - let me know what your thoughts are about that.
2. Our `RoleBinding` was calling out a `Role` for `ploigos-run-as-user-1001`, but we _actually_ create a `ClusterRole`, so I fixed that.
3. Needed to remove quotes for `psr --config` because I pass multiple args there and don't want them to get treated as one string

# releated
https://github.com/ploigos/ploigos-jenkins-library/pull/21