### PR TITLE
default to useing the latest git-init image because we are way behind

### DIFF
--- a/charts/ploigos-workflow/tekton-cluster-resources/templates/ClusterTask_ploigos-git-clone.yml
+++ b/charts/ploigos-workflow/tekton-cluster-resources/templates/ClusterTask_ploigos-git-clone.yml
@@ -86,7 +86,7 @@ spec:
     type: string
     description: |
       Container image to run the steps of this task in.
-    default: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.1
+    default: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.26.0
   - name: imagePullPolicy
     type: string
     description: |


### PR DESCRIPTION
# purpose

default to useing the latest git-init image because we are way behind and don't want to constently be checking for new version. users can always override if they don't want to use latest