### PR TITLE
updates needed to support Tekton Triggers v0.14.2 / OpenShift Pipelines 1.5.0

### DIFF
--- a/charts/ploigos-workflow/tekton-resources/templates/ServiceAccount_event-listener.yml
+++ b/charts/ploigos-workflow/tekton-resources/templates/ServiceAccount_event-listener.yml
@@ -16,7 +16,7 @@ metadata:
 rules:
 # EventListeners need to be able to fetch all namespaced resources
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  resources: ["*"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
 # configmaps is needed for updating logging config
@@ -24,7 +24,7 @@ rules:
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates
 - apiGroups: ["tekton.dev"]
-  resources: ["pipelineruns", "pipelineresources", "taskruns"]
+  resources: ["*"]
   verbs: ["create"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
@@ -56,3 +56,23 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "ploigos-workflow-tekton.eventListenerServiceAccountName" . }}
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ploigos-workflow-tekton.eventListenerServiceAccountName" . }}-cluster-resources
+  labels:
+    {{- include "ploigos-workflow.labels" $ | nindent 4 }}
+  annotations:
+    description: |
+      As of Tekton Triggers v0.14.2 you need "A Kubernetes ClusterRole that permits read access to
+      ClusterTriggerBindings objects".
+roleRef:
+  kind: ClusterRole
+  name: {{ $.Values.global.eventListenerClusterRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ploigos-workflow-tekton.eventListenerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/ploigos-workflow/tekton-resources/values.yaml
+++ b/charts/ploigos-workflow/tekton-resources/values.yaml
@@ -55,6 +55,21 @@ global:
   # Required if eventListenerCreateIngress is true.
   eventListenerIngressHost:
 
+  # As of Tekton Triggers v0.14.2 you need "A Kubernetes ClusterRole that permits read access to
+  # ClusterTriggerBindings objects".
+  #
+  # But the default ClusterRole for use by EventListeners that has these permissions,
+  # as of 8/9/21, isn't created by default in v0.14.2, or v0.15.0, but it is in the main branch.
+  # https://github.com/tektoncd/triggers/blob/3c4e26bbef121c51ab7d7941ffc59a7028bf55a8/config/200-clusterrole.yaml#L82-L92
+  #
+  # As workaround, currently (8/9/21) the OpenShift Pipelines operator (downstream of Tekton)
+  # does create a CluserRole with the needed permissions so can default to using that.
+  # Though on a none OpenShift cluster or an OpenShift cluster using upstream Tekton a custom
+  # ClusterRole will need to be created with the correct permissions and the name of that role
+  # used for this value until such time as Tekton releases with its
+  # 'tekton-triggers-eventlistener-clusterroles' ClusterRole.
+  eventListenerClusterRoleName: openshift-pipelines-clusterinterceptors
+
   # cleanupPipelineRunsToKeep is the number of Tekton PipelineRuns to keep when automatically
   # deleting old PipelineRuns for a given Pipeline.
   # Required.


### PR DESCRIPTION
# Purpose

updates needed to support Tekton Triggers v0.14.2 / OpenShift Pipelines 1.5.0

# integration testing

## tekton

### reference-quarkus-mvn
- [x] [minimum](https://console-openshift-console.apps.tssc.rht-set.com/k8s/ns/tekton-ploigos/tekton.dev~v1beta1~PipelineRun/ref-quarkus-mvn-tekton-min-fruit-617xzi/logs/setup-stage-gate)

### reference-spring-boot-mvn-jkube
- [x] [minimum](https://console-openshift-console.apps.tssc.rht-set.com/k8s/ns/tekton-ploigos/tekton.dev~v1beta1~PipelineRun/ref-spring-boot-jkube-min-hello-mwy4zq)