### PR TITLE
reduce the number of successful cronjobs that are cleaning up old pipeline runs to reduce noise

### DIFF
--- a/charts/ploigos-workflow/tekton-pipeline-everything/values.yaml
+++ b/charts/ploigos-workflow/tekton-pipeline-everything/values.yaml
@@ -66,7 +66,7 @@ global:
   # cleanupPipelineSuccessfulJobHistoryLimit is the number of Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.
-  cleanupPipelineSuccessfulJobHistoryLimit: 5
+  cleanupPipelineSuccessfulJobHistoryLimit: 1
   # cleanupPipelineFailedJobHistoryLimit is the number of failed Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.

--- a/charts/ploigos-workflow/tekton-pipeline-minimal/values.yaml
+++ b/charts/ploigos-workflow/tekton-pipeline-minimal/values.yaml
@@ -66,7 +66,7 @@ global:
   # cleanupPipelineSuccessfulJobHistoryLimit is the number of Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.
-  cleanupPipelineSuccessfulJobHistoryLimit: 5
+  cleanupPipelineSuccessfulJobHistoryLimit: 1
   # cleanupPipelineFailedJobHistoryLimit is the number of failed Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.

--- a/charts/ploigos-workflow/tekton-pipeline-typical/values.yaml
+++ b/charts/ploigos-workflow/tekton-pipeline-typical/values.yaml
@@ -66,7 +66,7 @@ global:
   # cleanupPipelineSuccessfulJobHistoryLimit is the number of Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.
-  cleanupPipelineSuccessfulJobHistoryLimit: 5
+  cleanupPipelineSuccessfulJobHistoryLimit: 1
   # cleanupPipelineFailedJobHistoryLimit is the number of failed Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.

--- a/charts/ploigos-workflow/tekton-resources/values.yaml
+++ b/charts/ploigos-workflow/tekton-resources/values.yaml
@@ -66,7 +66,7 @@ global:
   # cleanupPipelineSuccessfulJobHistoryLimit is the number of Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.
-  cleanupPipelineSuccessfulJobHistoryLimit: 5
+  cleanupPipelineSuccessfulJobHistoryLimit: 1
   # cleanupPipelineFailedJobHistoryLimit is the number of failed Job resources to keep created
   # by the CronJob for deleting old PipelineRuns.
   # Required.


### PR DESCRIPTION
# purpose

keeping 5 succesful cronjob runs used to cleanup old pipeline runs is just noisy, so reducing default.